### PR TITLE
Property Type 改為下拉選單選擇

### DIFF
--- a/app/Enums/PropertyType.php
+++ b/app/Enums/PropertyType.php
@@ -9,4 +9,15 @@ enum PropertyType: string
     case Numeric = 'NUMERIC';
     case Boolean = 'BOOLEAN';
     case String = 'STRING';
+
+    /**
+     * @return list<array{value: string, label: string}>
+     */
+    public static function selectOptions(): array
+    {
+        return array_map(
+            fn (self $type) => ['value' => $type->value, 'label' => $type->value],
+            self::cases(),
+        );
+    }
 }

--- a/resources/views/graph-schema/edge-property/create-or-edit.blade.php
+++ b/resources/views/graph-schema/edge-property/create-or-edit.blade.php
@@ -27,7 +27,13 @@
                         'isEditMode' => $isEditMode,
                     ])
 
-                    <x-forms.input id="age_property_type" label="Property Type" :value="$edgeProperty->age_property_type->value ?? ''" required />
+                    <x-forms.select
+                        id="age_property_type"
+                        label="Property Type"
+                        :value="$edgeProperty->age_property_type->value ?? ''"
+                        :options="\App\Enums\PropertyType::selectOptions()"
+                        required
+                    />
 
                     <div class="row mb-2">
                         <div class="col-md-10 ms-auto">

--- a/resources/views/graph-schema/vertex-property/create-or-edit.blade.php
+++ b/resources/views/graph-schema/vertex-property/create-or-edit.blade.php
@@ -27,7 +27,13 @@
                         'isEditMode' => $isEditMode,
                     ])
 
-                    <x-forms.input id="age_property_type" label="Property Type" :value="$vertexProperty->age_property_type->value ?? ''" required />
+                    <x-forms.select
+                        id="age_property_type"
+                        label="Property Type"
+                        :value="$vertexProperty->age_property_type->value ?? ''"
+                        :options="\App\Enums\PropertyType::selectOptions()"
+                        required
+                    />
 
                     <div class="row mb-2">
                         <div class="col-md-10 ms-auto">

--- a/tests/Feature/GraphSchema/EdgePropertyTest.php
+++ b/tests/Feature/GraphSchema/EdgePropertyTest.php
@@ -297,7 +297,12 @@ class EdgePropertyTest extends TestCase
             ->assertOk()
             ->assertSee('語言版本')
             ->assertSee('非多語系')
-            ->assertSee('繁體中文（zh_tw）');
+            ->assertSee('繁體中文（zh_tw）')
+            ->assertSee('id="age_property_type"', false)
+            ->assertSee('form-select', false)
+            ->assertSee('>INTEGER<', false)
+            ->assertSee('>STRING<', false)
+            ->assertDontSee('type="text" name="age_property_type"', false);
     }
 
     public function test_edit_form_shows_readonly_locale_and_property_name_for_localized_property(): void

--- a/tests/Feature/GraphSchema/VertexPropertyTest.php
+++ b/tests/Feature/GraphSchema/VertexPropertyTest.php
@@ -324,7 +324,12 @@ class VertexPropertyTest extends TestCase
             ->assertOk()
             ->assertSee('語言版本')
             ->assertSee('非多語系')
-            ->assertSee('繁體中文（zh_tw）');
+            ->assertSee('繁體中文（zh_tw）')
+            ->assertSee('id="age_property_type"', false)
+            ->assertSee('form-select', false)
+            ->assertSee('>INTEGER<', false)
+            ->assertSee('>STRING<', false)
+            ->assertDontSee('type="text" name="age_property_type"', false);
     }
 
     public function test_edit_form_shows_readonly_locale_and_property_name_for_localized_property(): void

--- a/tests/Unit/Enums/PropertyTypeTest.php
+++ b/tests/Unit/Enums/PropertyTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\PropertyType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PropertyTypeTest extends TestCase
+{
+    #[Test]
+    public function select_options_include_all_cases(): void
+    {
+        $options = PropertyType::selectOptions();
+
+        $this->assertCount(count(PropertyType::cases()), $options);
+
+        foreach (PropertyType::cases() as $type) {
+            $this->assertContains(
+                ['value' => $type->value, 'label' => $type->value],
+                $options,
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

將 Vertex Property 與 Edge Property 新增/編輯表單中的 **Property Type** 欄位，從文字輸入改為下拉選單，選項來自 `PropertyType` enum（INTEGER、FLOAT、NUMERIC、BOOLEAN、STRING）。

## Changes

- 在 `PropertyType` enum 新增 `selectOptions()` 方法，提供表單選項資料
- 更新 `vertex-property/create-or-edit.blade.php` 與 `edge-property/create-or-edit.blade.php`，改用 `x-forms.select` 元件
- 補充單元測試與 feature test 斷言，確認表單渲染為 `<select>` 而非文字輸入

## Test plan

- [x] `tests/Unit/Enums/PropertyTypeTest.php` 通過
- [ ] `tests/Feature/GraphSchema/VertexPropertyTest.php`（需資料庫環境）
- [ ] `tests/Feature/GraphSchema/EdgePropertyTest.php`（需資料庫環境）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa1dd0a-f259-461b-a3c4-ccea5c1303b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa1dd0a-f259-461b-a3c4-ccea5c1303b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

