### PR TITLE
Property Type 簡化為 FLOAT 並改為下拉選單

### DIFF
--- a/.spec/revision.md
+++ b/.spec/revision.md
@@ -34,7 +34,7 @@ app/
 │   └── Graph/           # 圖資料瀏覽（Vertex 列表與詳情）
 ├── Models/              # Eloquent models
 ├── Rules/GraphSchema/   # 自訂驗證規則（AGE label/property 命名規則）
-├── Enums/               # PropertyType enum（INTEGER, FLOAT, NUMERIC, BOOLEAN, STRING）
+├── Enums/               # PropertyType enum（INTEGER, FLOAT, BOOLEAN, STRING）
 └── Services/            # MenuService
 database/
 ├── migrations/          # 關聯式 DB schema

--- a/app/Enums/PropertyType.php
+++ b/app/Enums/PropertyType.php
@@ -6,7 +6,6 @@ enum PropertyType: string
 {
     case Integer = 'INTEGER';
     case Float = 'FLOAT';
-    case Numeric = 'NUMERIC';
     case Boolean = 'BOOLEAN';
     case String = 'STRING';
 

--- a/app/Enums/PropertyType.php
+++ b/app/Enums/PropertyType.php
@@ -9,4 +9,15 @@ enum PropertyType: string
     case Numeric = 'NUMERIC';
     case Boolean = 'BOOLEAN';
     case String = 'STRING';
+
+    /**
+     * @return list<array{value: string, label: string}>
+     */
+    public static function selectOptions(): array
+    {
+        return array_map(
+            fn (self $type) => ['value' => $type->value, 'label' => $type->value],
+            self::cases(),
+        );
+    }
 }

--- a/app/Services/Revision/RevisionActionValidator.php
+++ b/app/Services/Revision/RevisionActionValidator.php
@@ -493,7 +493,7 @@ class RevisionActionValidator
     {
         return match ($propertyType) {
             PropertyType::Integer => preg_match('/^-?\\d+$/', $value) === 1,
-            PropertyType::Float, PropertyType::Numeric => preg_match('/^-?(?:\\d+|\\d*\\.\\d+)$/', $value) === 1,
+            PropertyType::Float => preg_match('/^-?(?:\\d+|\\d*\\.\\d+)$/', $value) === 1,
             PropertyType::Boolean => in_array(strtolower($value), ['true', 'false'], true),
             PropertyType::String => true,
         };

--- a/app/Services/Revision/RevisionApplyService.php
+++ b/app/Services/Revision/RevisionApplyService.php
@@ -306,7 +306,7 @@ class RevisionApplyService
     {
         return match ($propertyType) {
             PropertyType::Integer => (int) $value,
-            PropertyType::Float, PropertyType::Numeric => (float) $value,
+            PropertyType::Float => (float) $value,
             PropertyType::Boolean => strtolower($value) === 'true',
             PropertyType::String => $value,
         };

--- a/app/Support/LocalizedPropertyLabelResolver.php
+++ b/app/Support/LocalizedPropertyLabelResolver.php
@@ -79,7 +79,11 @@ class LocalizedPropertyLabelResolver
         if ($vertexTypeLabel !== null) {
             $vertexType = $vertexTypes->firstWhere('age_label_name', $vertexTypeLabel);
 
-            return $vertexType?->properties ?? collect();
+            if ($vertexType === null) {
+                return collect();
+            }
+
+            return $vertexType->properties;
         }
 
         return $vertexTypes->flatMap(fn ($vertexType) => $vertexType->properties);
@@ -100,7 +104,11 @@ class LocalizedPropertyLabelResolver
         if ($edgeTypeLabel !== null) {
             $edgeType = $edgeTypes->firstWhere('age_label_name', $edgeTypeLabel);
 
-            return $edgeType?->properties ?? collect();
+            if ($edgeType === null) {
+                return collect();
+            }
+
+            return $edgeType->properties;
         }
 
         return $edgeTypes->flatMap(fn ($edgeType) => $edgeType->properties);

--- a/database/migrations/2026_07_02_020722_migrate_numeric_property_type_to_float.php
+++ b/database/migrations/2026_07_02_020722_migrate_numeric_property_type_to_float.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::table('vertex_properties')
+            ->where('age_property_type', 'NUMERIC')
+            ->update(['age_property_type' => 'FLOAT']);
+
+        DB::table('edge_properties')
+            ->where('age_property_type', 'NUMERIC')
+            ->update(['age_property_type' => 'FLOAT']);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Cannot distinguish rows migrated from NUMERIC vs originally FLOAT.
+    }
+};

--- a/resources/views/graph-schema/edge-property/create-or-edit.blade.php
+++ b/resources/views/graph-schema/edge-property/create-or-edit.blade.php
@@ -27,7 +27,13 @@
                         'isEditMode' => $isEditMode,
                     ])
 
-                    <x-forms.input id="age_property_type" label="Property Type" :value="$edgeProperty->age_property_type->value ?? ''" required />
+                    <x-forms.select
+                        id="age_property_type"
+                        label="Property Type"
+                        :value="$edgeProperty->age_property_type->value ?? ''"
+                        :options="\App\Enums\PropertyType::selectOptions()"
+                        required
+                    />
 
                     <div class="row mb-2">
                         <div class="col-md-10 ms-auto">

--- a/resources/views/graph-schema/vertex-property/create-or-edit.blade.php
+++ b/resources/views/graph-schema/vertex-property/create-or-edit.blade.php
@@ -27,7 +27,13 @@
                         'isEditMode' => $isEditMode,
                     ])
 
-                    <x-forms.input id="age_property_type" label="Property Type" :value="$vertexProperty->age_property_type->value ?? ''" required />
+                    <x-forms.select
+                        id="age_property_type"
+                        label="Property Type"
+                        :value="$vertexProperty->age_property_type->value ?? ''"
+                        :options="\App\Enums\PropertyType::selectOptions()"
+                        required
+                    />
 
                     <div class="row mb-2">
                         <div class="col-md-10 ms-auto">

--- a/tests/Feature/GraphSchema/EdgePropertyTest.php
+++ b/tests/Feature/GraphSchema/EdgePropertyTest.php
@@ -297,7 +297,12 @@ class EdgePropertyTest extends TestCase
             ->assertOk()
             ->assertSee('語言版本')
             ->assertSee('非多語系')
-            ->assertSee('繁體中文（zh_tw）');
+            ->assertSee('繁體中文（zh_tw）')
+            ->assertSee('id="age_property_type"', false)
+            ->assertSee('form-select', false)
+            ->assertSee('>INTEGER<', false)
+            ->assertSee('>STRING<', false)
+            ->assertDontSee('type="text" name="age_property_type"', false);
     }
 
     public function test_edit_form_shows_readonly_locale_and_property_name_for_localized_property(): void

--- a/tests/Feature/GraphSchema/VertexPropertyTest.php
+++ b/tests/Feature/GraphSchema/VertexPropertyTest.php
@@ -324,7 +324,12 @@ class VertexPropertyTest extends TestCase
             ->assertOk()
             ->assertSee('語言版本')
             ->assertSee('非多語系')
-            ->assertSee('繁體中文（zh_tw）');
+            ->assertSee('繁體中文（zh_tw）')
+            ->assertSee('id="age_property_type"', false)
+            ->assertSee('form-select', false)
+            ->assertSee('>INTEGER<', false)
+            ->assertSee('>STRING<', false)
+            ->assertDontSee('type="text" name="age_property_type"', false);
     }
 
     public function test_edit_form_shows_readonly_locale_and_property_name_for_localized_property(): void

--- a/tests/Unit/Enums/PropertyTypeTest.php
+++ b/tests/Unit/Enums/PropertyTypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\PropertyType;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class PropertyTypeTest extends TestCase
+{
+    #[Test]
+    public function select_options_include_all_cases(): void
+    {
+        $options = PropertyType::selectOptions();
+
+        $this->assertCount(count(PropertyType::cases()), $options);
+
+        foreach (PropertyType::cases() as $type) {
+            $this->assertContains(
+                ['value' => $type->value, 'label' => $type->value],
+                $options,
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

將 Property Type 簡化為只保留 `FLOAT`，移除與之功能重疊的 `NUMERIC`。此分支亦包含先前的下拉選單改動。

## Changes

- 從 `PropertyType` enum 移除 `NUMERIC`
- 更新 Revision 驗證與套用邏輯，僅處理 `FLOAT`
- 新增 migration，將既有 `vertex_properties` / `edge_properties` 中 `NUMERIC` 資料轉為 `FLOAT`
- Property Type 表單改為下拉選單（INTEGER、FLOAT、BOOLEAN、STRING）

## Test plan

- [x] devcontainer 環境執行相關測試：27 passed
- [x] migration 已在 devcontainer 成功執行
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fa1dd0a-f259-461b-a3c4-ccea5c1303b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fa1dd0a-f259-461b-a3c4-ccea5c1303b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

