### PR TITLE
Add Cursor PR rule: branch from develop, require test & PHPStan before push

### DIFF
--- a/.cursor/rules/pull-request.mdc
+++ b/.cursor/rules/pull-request.mdc
@@ -1,0 +1,37 @@
+---
+description: Pull request 分支與 push 前驗證規範
+alwaysApply: true
+---
+
+# Pull Request 規則
+
+## 分支策略
+
+- **Base branch**：一律從 `develop` 開分支。
+- **Target branch**：PR 一律合併到 `develop`，不要對 `main` 開 PR。
+- 開始工作前先確認本地 `develop` 已更新：
+
+```bash
+git fetch origin develop
+git checkout develop
+git pull origin develop
+git checkout -b <branch-name>
+```
+
+## Push 前驗證（必須手動執行）
+
+在 `git push` 之前，**必須**在本機手動跑完以下檢查且全部通過：
+
+```bash
+composer run test
+composer run phpstan
+```
+
+- 不要跳過測試或 PHPStan。
+- 若只改動局部邏輯，至少跑相關測試；push 前仍須跑完整 `composer run test`。
+- PHP 檔案若有修改，push 前執行 `vendor/bin/pint --dirty`。
+
+## 建立 PR 時
+
+- PR base 設為 `develop`。
+- PR 描述中列出已執行的驗證命令與結果（test、phpstan）。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

新增 `.cursor/rules/pull-request.mdc`，讓 Cursor Agent 遵循專案的 PR 工作流程：

- 一律從 `develop` 開分支
- PR 目標分支為 `develop`
- **push 前**必須手動執行 `composer run test` 與 `composer run phpstan`

此 PR 從 `develop` 重開，僅包含上述 rule 檔案（取代 #24）。

## 驗證

此變更僅新增 Cursor rule 設定檔，未修改應用程式碼。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d6d5984-4fcc-4af6-be5c-8a089202f527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d6d5984-4fcc-4af6-be5c-8a089202f527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

