### PR TITLE
Add GitHub Action to verify frontend asset builds

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,36 @@
+name: Frontend Build
+
+on:
+  push:
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'vite.config.js'
+      - 'resources/**'
+      - '.github/workflows/frontend.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build frontend assets
+        run: pnpm run build
+
+      - name: Verify build output
+        run: test -f public/build/manifest.json

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -50,11 +50,6 @@ jobs:
         php artisan migrate --force
         php artisan migrate --database=pgsql-age --path=database/migrations-age --force
         php artisan app:apply-role-and-permission-command
-        mkdir .bin
-        corepack enable --install-directory .bin
-        export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
-        .bin/pnpm install
-        .bin/pnpm run build
 
     - name: Test
       run: composer run test

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,10 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

新增獨立的 GitHub Actions workflow 驗證前端打包，並從 PHP CI 移除重複的建置步驟。測試改以 `withoutVite()` 避免 PHP CI 依賴 `public/build/manifest.json`。

## Changes

- 新增 `.github/workflows/frontend.yml`
  - 使用 Node.js 22 + pnpm
  - 執行 `pnpm install --frozen-lockfile` 與 `pnpm run build`
  - 確認 `public/build/manifest.json` 已產生
- 從 `.github/workflows/php.yml` 移除 `pnpm install` 與 `pnpm run build`
- 在 `tests/TestCase.php` 加入 `withoutVite()`，讓渲染 `@vite` 的 feature test 不需實際建置前端

## Trigger paths

`frontend.yml` 僅在以下路徑有變更時執行：

- `package.json`、`pnpm-lock.yaml`
- `vite.config.js`
- `resources/**`
- `.github/workflows/frontend.yml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c99b5a29-63d3-48dc-8468-79d3691f294b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c99b5a29-63d3-48dc-8468-79d3691f294b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

