### PR TITLE
在 footer 加上 Powered by CoHistograph

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -18,7 +18,9 @@
     color: #ddd;
 }
 
-.footer > div.container > .breadcrumb a {
+.footer > div.container > .breadcrumb a,
+.footer > div.container > .powered-by,
+.footer > div.container > .powered-by a {
     color: #ddd;
 }
 

--- a/resources/views/components/footer.blade.php
+++ b/resources/views/components/footer.blade.php
@@ -1,9 +1,12 @@
 <footer class="footer bg-dark">
-    <div class="container">
-        <ol class="breadcrumb">
+    <div class="container d-flex align-items-center justify-content-between flex-wrap gap-2">
+        <ol class="breadcrumb mb-0">
             <li class="breadcrumb-item">
                 {{ html()->a(route('faq'), '常見問題') }}
             </li>
         </ol>
+        <div class="powered-by">
+            Powered by {{ html()->a('https://github.com/danny50610/CoHistograph', 'CoHistograph')->target('_blank')->attribute('rel', 'noopener noreferrer') }}
+        </div>
     </div>
 </footer>

--- a/tests/Feature/FooterTest.php
+++ b/tests/Feature/FooterTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class FooterTest extends TestCase
+{
+    public function test_footer_contains_powered_by_cohistograph_link(): void
+    {
+        $this->get(route('faq'))
+            ->assertOk()
+            ->assertSee('Powered by', false)
+            ->assertSee('CoHistograph', false)
+            ->assertSee('https://github.com/danny50610/CoHistograph', false)
+            ->assertSee('target="_blank"', false)
+            ->assertSee('rel="noopener noreferrer"', false);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 在共用 footer 右側加上 `Powered by CoHistograph`，連結至 https://github.com/danny50610/CoHistograph（新分頁開啟）
- 補上 footer 樣式，讓 powered-by 文字與既有連結顏色一致
- 新增 `FooterTest` 驗證文字與連結屬性

## Test plan
- [x] `php artisan test --compact tests/Feature/FooterTest.php`（通過）
- [x] `composer run phpstan`（通過，No errors）
- [ ] `composer run test`（本機 Cloud Agent 環境無 PostgreSQL/AGE，多數 DB 相依測試無法執行；`FooterTest` 已通過）

## 驗證結果
- `php artisan test --compact tests/Feature/FooterTest.php`：1 passed
- `composer run phpstan`：OK, No errors
- `vendor/bin/pint --dirty`：已執行

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49c3e8ba-74ff-4069-88df-54ef71c88056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49c3e8ba-74ff-4069-88df-54ef71c88056"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

