### PR TITLE
Fix Inertia boot error on non-Inertia Blade pages

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -4,9 +4,30 @@ import { createInertiaApp } from '@inertiajs/vue3';
 // TODO: 注入 axios ?
 // https://inertiajs.com/docs/v3/installation/client-side-setup#http-client
 
-createInertiaApp({
-    resolve: (name) => {
-        const pages = import.meta.glob('./Pages/**/*.vue');
-        return pages[`./Pages/${name}.vue`]();
-    },
-});
+// Blade 頁面也會載入此 entry；僅在有 Inertia page component 時才啟動。
+function hasInertiaPage(id = 'app') {
+    const scriptEl = document.querySelector(`script[data-page="${id}"][type="application/json"]`);
+
+    if (!scriptEl?.textContent) {
+        return false;
+    }
+
+    try {
+        const page = JSON.parse(scriptEl.textContent);
+
+        return Boolean(page?.component);
+    } catch {
+        return false;
+    }
+}
+
+if (hasInertiaPage()) {
+    createInertiaApp({
+        resolve: (name) => {
+            const pages = import.meta.glob('./Pages/**/*.vue');
+
+            return pages[`./Pages/${name}.vue`]();
+        },
+    });
+}
+

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -77,7 +77,9 @@
 <div style="min-height: calc(100vh - 56px - 54px - 2rem);" class="mt-3 mb-3">
     @include('components.page-alert')
     @yield('content')
-    <x-inertia::app />
+    @if (isset($page['component']))
+        <x-inertia::app />
+    @endif
 </div>
 
 @include('components.footer')

--- a/tests/Feature/InertiaRootMountTest.php
+++ b/tests/Feature/InertiaRootMountTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class InertiaRootMountTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function test_blade_pages_do_not_render_inertia_root(): void
+    {
+        $this->get(route('index'))
+            ->assertOk()
+            ->assertDontSee('data-page="app"', false)
+            ->assertDontSee('<div id="app"></div>', false);
+    }
+
+    public function test_inertia_pages_render_inertia_root(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('graph-schema.visualization'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('GraphSchema/Visualization')
+            )
+            ->assertSee('data-page="app"', false)
+            ->assertSee('<div id="app"></div>', false);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Blade pages share `layouts.app`, which always loads `resources/js/app.js` and previously always called `createInertiaApp()`.
- On non-Inertia pages, `<x-inertia::app />` still rendered an empty page JSON (`[]`), so `resolve(undefined)` threw `Object.assign(...)[e] is not a function` in `app-DZDd3OEk.js`.
- Guard Inertia boot on a real page `component`, and only render `<x-inertia::app />` when `$page['component']` is present.

## Changes
- `resources/js/app.js`: only call `createInertiaApp()` when page JSON has a `component`
- `resources/views/layouts/app.blade.php`: only render `<x-inertia::app />` for Inertia responses
- `tests/Feature/InertiaRootMountTest.php`: cover Blade vs Inertia root markup

## Verification
- `php artisan test --compact tests/Feature/InertiaRootMountTest.php tests/Feature/FooterTest.php tests/Feature/GraphSchema/VisualizationTest.php` → **6 passed**
- `composer run phpstan` → **No errors**
- `vendor/bin/pint --dirty` → clean
- Full `composer run test` fails in this environment due to missing Role seeds / AGE Postgres requirements (pre-existing env issue, unrelated to this change)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a47f9e22-a128-464c-a1d5-166f12e16050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a47f9e22-a128-464c-a1d5-166f12e16050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

